### PR TITLE
.zenodo.json: link deposit to BANC paper (Nature + bioRxiv)

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -19,6 +19,18 @@
 
     "title": "Connectome Influence Calculator",
 
-    "keywords": ["Connectome", "Drosophila", "Dynamics", "Model", "RNN"]
-    
+    "keywords": ["Connectome", "Drosophila", "Dynamics", "Model", "RNN"],
+
+    "related_identifiers": [
+        {
+            "relation": "isSupplementTo",
+            "identifier": "10.1038/s41586-026-10735-w",
+            "resource_type": "publication-article"
+        },
+        {
+            "relation": "isSupplementTo",
+            "identifier": "10.1101/2025.07.31.667571",
+            "resource_type": "publication-preprint"
+        }
+    ]
 }


### PR DESCRIPTION
Links the `ConnectomeInfluenceCalculator` Zenodo deposit ([10.5281/zenodo.15999930](https://doi.org/10.5281/zenodo.15999930)) back to the BANC connectome paper that uses it, so the deposit's DataCite record records the relationship and the badge appears on the paper's reference graph.

## Summary
Adds two `related_identifiers` to `.zenodo.json`:
- `isSupplementTo` → `10.1038/s41586-026-10735-w` (Nature article, open access)
- `isSupplementTo` → `10.1101/2025.07.31.667571` (bioRxiv preprint, retained for backward compatibility)

## Context
`ConnectomeInfluenceCalculator` is used in:

> Bates AS, Phelps JS, Kim M, Yang HHJ, *et al.* (2026). *Distributed control circuits across a brain-and-cord connectome.* **Nature** (open access). https://doi.org/10.1038/s41586-026-10735-w

…to compute all-to-all + sensory→effector + AN/DN→effector influence tables for the BANC connectome. The natverse wrapper [`influencer`](https://github.com/natverse/influencer) (which directly wraps this library) declares the relationship the other way (`isDerivedFrom` → `10.5281/zenodo.15999930`); this PR closes the loop.

## Effect on existing deposit
The current Zenodo record (DOI `15999930`) is immutable. This change takes effect at the **next** GitHub release whenever you cut one — the new version of the deposit will carry the `related_identifiers` block.

## Test plan
- [x] `.zenodo.json` parses as valid JSON.
- [ ] After next release: confirm Zenodo deposit page shows "References / is supplement to" link to the Nature article.
